### PR TITLE
Moves locutus to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   ],
   "author": "James K Fry",
   "license": "MIT",
+  "dependencies": {
+    "locutus": "^2.0.11"
+  },
   "devDependencies": {
     "@babel/cli": "^7.7.7",
     "@babel/core": "^7.7.7",
@@ -26,6 +29,5 @@
     "@babel/plugin-transform-runtime": "^7.6.2",
     "@babel/preset-env": "^7.7.7",
     "jest": "^24.9.0",
-    "locutus": "^2.0.11"
   }
 }


### PR DESCRIPTION
Locutus is a regular dependency as noted in #16. This moves Locutus to the right spot in package.json. 